### PR TITLE
Feature(api & admin): Refund invoice

### DIFF
--- a/apps/admin/src/components/invoices/Create.tsx
+++ b/apps/admin/src/components/invoices/Create.tsx
@@ -8,6 +8,7 @@ import
     ReferenceArrayInput, AutocompleteInput,
     SimpleFormIterator,
     TabbedForm,
+    ReferenceInput,
 } from "react-admin";
 //@ts-ignore
 import { RichTextInput } from 'ra-input-rich-text';
@@ -19,8 +20,7 @@ export const CreateInvoices = (props: any) =>
     <Create {...props}>
         <TabbedForm>
             <FormTab label="General">
-                {/* @ts-ignore */}
-                <ReferenceArrayInput filterToQuery={searchText => ({
+                <ReferenceInput filterToQuery={(searchText: string) => ({
                     "personal.first_name": searchText,
                 })} perPage={100} source="customer_uid" reference="customers">
                     <AutocompleteInput
@@ -30,7 +30,7 @@ export const CreateInvoices = (props: any) =>
                         fullWidth
                         optionText={RenderFullName}
                     />
-                </ReferenceArrayInput>
+                </ReferenceInput>
                 <AutocompleteInput isRequired={true} source="status" choices={[
                     { id: "draft", name: "draft" },
                     { id: "refunded", name: "refunded" },
@@ -55,6 +55,7 @@ export const CreateInvoices = (props: any) =>
                 <NumberInput fullWidth min={0} max={100} isRequired={true} label="Tax Rate" source="tax_rate" />
                 <BooleanInput label="Paid" defaultValue={false} source="paid" />
                 <BooleanInput label="Notified" defaultValue={false} source="notified" />
+                <BooleanInput label="Send Email" defaultValue={false} source="send_email" />
             </FormTab>
             <FormTab label="Dates">
                 <DateInput label="Invoiced date" source="dates.invoice_date" defaultValue={new Date().toLocaleDateString()} />
@@ -70,7 +71,7 @@ export const CreateInvoices = (props: any) =>
                         <NumberInput isRequired={true} label="Amount" source="amount" />
                         <NumberInput label="Quantity" defaultValue={1} source="quantity" />
                         {/* @ts-ignore */}
-                        <ReferenceArrayInput filterToQuery={searchText => ({
+                        <ReferenceInput filterToQuery={searchText => ({
                             "name": searchText,
                         })} perPage={100} source="product_id" reference="products">
                             <AutocompleteInput
@@ -80,7 +81,7 @@ export const CreateInvoices = (props: any) =>
                                 fullWidth
                                 optionText={(r: any) => `${r.name} - (${r.id})`}
                             />
-                        </ReferenceArrayInput>
+                        </ReferenceInput>
                     </SimpleFormIterator>
                 </ArrayInput>
 

--- a/apps/admin/src/components/invoices/Edit.tsx
+++ b/apps/admin/src/components/invoices/Edit.tsx
@@ -8,6 +8,7 @@ import
     ReferenceArrayInput, ReferenceInput, AutocompleteInput,
     SimpleFormIterator,
     TabbedForm,
+    FormDataConsumer,
 } from "react-admin";
 import { RichTextInput } from 'ra-input-rich-text';
 import { currencyCodes } from "lib/Currencies";
@@ -57,6 +58,27 @@ export const EditInvoices = (props: any) =>
                     <NumberInput fullWidth min={0} max={100} isRequired={true} label="Tax Rate" source="tax_rate" />
                     <BooleanInput label="Paid" defaultValue={false} source="paid" />
                     <BooleanInput label="Notified" defaultValue={false} source="notified" />
+
+                    <FormDataConsumer>
+                        {({ formData }) => (
+                            formData.paid &&
+                            formData.status === "refunded" &&
+                            formData.payment_method === "credit_card" &&
+                            !formData.extra.refunded
+                        ) && (
+                                <BooleanInput disabled={formData.refund_email} label="Refund this invoice?" helperText="Warning: Only works for Credit card! This will refund automatically and send email, click on 'Refund Email' to send email if refunded" source="refund_invoice" />
+                            )}
+                    </FormDataConsumer>
+
+                    <FormDataConsumer>
+                        {({ formData }) => (
+                            formData.paid &&
+                            formData.status === "refunded"
+                        ) && (
+                                <BooleanInput disabled={formData.refund_invoice} label="Refund Email" source="refund_email" />
+                            )}
+                    </FormDataConsumer>
+
                 </FormTab>
 
                 <FormTab label="Dates">

--- a/apps/api/src/Cache/reCache.ts
+++ b/apps/api/src/Cache/reCache.ts
@@ -238,6 +238,13 @@ export async function reCache_Invoices()
                 o.markModified("customer_uid");
                 await o.save();
             }
+
+            if (!o.extra)
+            {
+                o.extra = {};
+                await o.save();
+            }
+
             Logger.cache(`Caching invoice ${o.uid}`);
             CacheInvoice.set(o.uid, o);
         }

--- a/apps/api/src/Cache/reCache.ts
+++ b/apps/api/src/Cache/reCache.ts
@@ -241,6 +241,7 @@ export async function reCache_Invoices()
 
             if (!o.extra)
             {
+                // @ts-ignore
                 o.extra = {};
                 await o.save();
             }

--- a/apps/api/src/Database/Models/Invoices.model.ts
+++ b/apps/api/src/Database/Models/Invoices.model.ts
@@ -128,6 +128,11 @@ const InvoiceSchema = new Schema
                 default: 'USD',
             },
 
+            extra: {
+                type: Object,
+                default: {},
+            },
+
         },
         {
             timestamps: true,

--- a/apps/api/src/Email/Templates/Invoices/Refunded.invoice.template.ts
+++ b/apps/api/src/Email/Templates/Invoices/Refunded.invoice.template.ts
@@ -8,7 +8,7 @@ export default async (invoice: IInvoice & IInvoiceMethods, customer: ICustomer) 
 <div>
     <h1>Hello ${getFullName(customer)}.</h1>
     <p>
-        This is a notice that an invoice has been refunded.
+        This is a notice that your invoice <strong>(#${invoice.id})</strong> has been refunded.
     </p>
     <p>
         <strong>Invoice number:</strong> ${invoice.id}

--- a/apps/api/src/Email/Templates/Invoices/Refunded.invoice.template.ts
+++ b/apps/api/src/Email/Templates/Invoices/Refunded.invoice.template.ts
@@ -1,0 +1,30 @@
+import { stripIndents } from "common-tags";
+import { ICustomer } from "interfaces/Customer.interface";
+import { IInvoice, IInvoiceMethods } from "interfaces/Invoice.interface";
+import getFullName from "../../../Lib/Customers/getFullName";
+import UseStyles from "../General/UseStyles";
+
+export default async (invoice: IInvoice & IInvoiceMethods, customer: ICustomer) => await UseStyles(stripIndents`
+<div>
+    <h1>Hello ${getFullName(customer)}.</h1>
+    <p>
+        This is a notice that an invoice has been refunded.
+    </p>
+    <p>
+        <strong>Invoice number:</strong> ${invoice.id}
+    </p>
+    <p>
+        <strong>Tax due:</strong> ${invoice.tax_rate}%
+    </p>
+    <p>
+        <strong>Amount:</strong> ${invoice.getTotalAmount({ tax: false, currency: false, symbol: false }).toFixed(2)} ${(invoice.currency)}
+    </p>
+
+    <p>
+        <strong>
+            Total refunded:
+        </strong>
+        ${invoice.getTotalAmount({ tax: true, currency: false, symbol: false }).toFixed(2)} ${invoice.currency} (${invoice.tax_rate}%)
+    </p>
+</div>
+`);

--- a/apps/api/src/Payments/Stripe.ts
+++ b/apps/api/src/Payments/Stripe.ts
@@ -2,7 +2,6 @@ import stripe from "stripe";
 import { Company_Currency, DebugMode, Full_Domain, Stripe_SK_Live, Stripe_SK_Test } from "../Config";
 import CustomerModel from "../Database/Models/Customers/Customer.model";
 import InvoiceModel from "../Database/Models/Invoices.model";
-import { ICreateCreditIntentOptions } from "interfaces/Stripe.interface";
 import TransactionsModel from "../Database/Models/Transactions.model";
 import { sendEmail } from "../Email/Send";
 import NewTransactionTemplate from "../Email/Templates/Transaction/NewTransaction.template";
@@ -122,6 +121,16 @@ export const CreatePaymentIntent = async (invoice: IInvoice<"credit_card">) =>
 };
 
 export const RetrievePaymentIntent = async (payment_intent: string) => (await Stripe.paymentIntents.retrieve(payment_intent));
+
+export const refundPaymentIntent = async (payment_intent_id: stripe.PaymentIntent["id"]) =>
+{
+    const intent = await Stripe.paymentIntents.retrieve(payment_intent_id);
+    if (intent.status !== "succeeded")
+        throw new Error("Payment intent is not succeeded");
+    return await Stripe.refunds.create({
+        payment_intent: payment_intent_id,
+    });
+}
 
 export const createSetupIntent = async (id: ICustomer["id"]) =>
 {

--- a/apps/api/src/Payments/Stripe.ts
+++ b/apps/api/src/Payments/Stripe.ts
@@ -58,7 +58,7 @@ const cacheSetupIntents = new Map<string, stripe.Response<stripe.SetupIntent>>()
 // }
 
 // Create a method that will create a payment intent from an order
-export const CreatePaymentIntent = async (invoice: IInvoice) =>
+export const CreatePaymentIntent = async (invoice: IInvoice<"credit_card">) =>
 {
     if (cacheIntents.has(invoice.uid))
         return cacheIntents.get(invoice.uid) as stripe.Response<stripe.PaymentIntent>;
@@ -110,6 +110,11 @@ export const CreatePaymentIntent = async (invoice: IInvoice) =>
             invoice_uid: invoice.uid,
         },
     }));
+
+    invoice.extra.stripe_payment_intent_id = intent.id;
+
+    // Save invoice
+    await InvoiceModel.updateOne({ id: invoice.id }, { $set: { extra: invoice.extra } }).exec();
 
     cacheIntents.set(invoice.uid, intent);
 

--- a/apps/api/src/Server/Routes/v2/Invoices/Invoices.controller.ts
+++ b/apps/api/src/Server/Routes/v2/Invoices/Invoices.controller.ts
@@ -5,14 +5,33 @@ import { IInvoice } from "interfaces/Invoice.interface";
 import { idInvoice } from "../../../../Lib/Generator";
 import { APIError, APISuccess } from "../../../../Lib/Response";
 import BaseModelAPI from "../../../../Models/BaseModelAPI";
+import { refundPaymentIntent } from "../../../../Payments/Stripe";
+import { sendEmail } from "../../../../Email/Send";
+import CustomerModel from "../../../../Database/Models/Customers/Customer.model";
+import RefundedInvoiceTemplate from "../../../../Email/Templates/Invoices/Refunded.invoice.template";
+import { sendInvoiceEmail } from "../../../../Lib/Invoices/SendEmail";
 
 const API = new BaseModelAPI<IInvoice>(idInvoice, InvoiceModel);
 
 function insert(req: Request, res: Response)
 {
     API.create(req.body)
-        .then((result) =>
+        .then(async (result) =>
         {
+            const send_email = req.body.send_email ?? false;
+
+            if (send_email)
+            {
+                const customer = await CustomerModel.findOne({
+                    $or: [
+                        { id: result.customer_uid },
+                        { uid: result.customer_uid as any }
+                    ]
+                });
+                if (customer)
+                    // @ts-ignore
+                    await sendInvoiceEmail(result, customer);
+            }
 
             mainEvent.emit("invoice_created", result);
 
@@ -38,11 +57,90 @@ function list(req: Request, res: Response)
     });
 }
 
-function patch(req: Request, res: Response)
+async function patch(req: Request, res: Response)
 {
     const paid = req.body.paid ?? false;
-    API.findAndPatch((req.params.uid as IInvoice["uid"]), req.body).then((result) =>
+    const refund_invoice = req.body.refund_invoice ?? false;
+    const refund_email = req.body.refund_email ?? false;
+    const currentInvoice = await InvoiceModel.findOne({
+        $or: [
+            { id: req.params.uid },
+            { uid: req.params.uid as any }
+        ]
+    });
+    API.findAndPatch((req.params.uid as IInvoice["uid"]), req.body).then(async (result) =>
     {
+
+        if (currentInvoice)
+            if (
+                // Checking for cautions if we didn't do this by mistake
+                // status needs to be refunded
+                result.status === "refunded" &&
+                // We have also marked it as refund
+                refund_invoice &&
+                // And we haven't refunded it already.
+                !currentInvoice.extra?.refunded &&
+                // We must ensure it is paid
+                result.paid &&
+                // And we have a payment intent
+                result.extra?.stripe_payment_intent_id
+            )
+            {
+                const nResult = result as unknown as IInvoice<"credit_card", "refunded">;
+                const refunded = await refundPaymentIntent(nResult.extra.stripe_payment_intent_id);
+                if (refunded.status === "succeeded")
+                {
+                    // @ts-ignore
+                    nResult.extra = {
+                        ...nResult.extra,
+                        refunded: true
+                    };
+                    // Update invoice
+                    await InvoiceModel.updateOne({
+                        id: currentInvoice.id
+                    }, {
+                        $set: {
+                            extra: nResult.extra
+                        }
+                    });
+
+                    const customer = await CustomerModel.findOne({
+                        $or: [
+                            { id: nResult.customer_uid },
+                            { uid: nResult.customer_uid as any }
+                        ]
+                    });
+                    if (customer)
+                        await sendEmail({
+                            receiver: customer.personal.email,
+                            subject: `Invoice #${result.id} has been refunded`,
+                            body: {
+                                // @ts-ignore
+                                body: await RefundedInvoiceTemplate(result, customer)
+                            }
+                        });
+                }
+            }
+
+        if (refund_email && !refund_invoice)
+        {
+            const customer = await CustomerModel.findOne({
+                $or: [
+                    { id: result.customer_uid },
+                    { uid: result.customer_uid as any }
+                ]
+            });
+            if (customer)
+                await sendEmail({
+                    receiver: customer.personal.email,
+                    subject: `Invoice #${result.id} has been refunded`,
+                    body: {
+                        // @ts-ignore
+                        body: await RefundedInvoiceTemplate(result, customer)
+                    }
+                });
+        }
+
         if (paid !== result.paid && result.paid)
             mainEvent.emit("invoice_paid", result);
         // @ts-ignore

--- a/apps/api/src/Server/Routes/v2/Stripe/Stripe.config.ts
+++ b/apps/api/src/Server/Routes/v2/Stripe/Stripe.config.ts
@@ -12,6 +12,7 @@ import Stripe from "stripe";
 import { CreatePaymentIntent, createSetupIntent, markInvoicePaid, RetrievePaymentIntent, RetrieveSetupIntent } from "../../../../Payments/Stripe";
 import CustomerModel from "../../../../Database/Models/Customers/Customer.model";
 import stripeWebhookEvent from "../../../../Events/Stripe.event";
+import { IInvoice } from "interfaces/Invoice.interface";
 const stripe = new Stripe(DebugMode ? Stripe_SK_Test : Stripe_SK_Live, {
     apiVersion: "2020-08-27",
 });
@@ -37,7 +38,7 @@ class StripeRouter
             if (invoice.paid)
                 return APIError("Invoice already paid")(res);
 
-            const intent = await CreatePaymentIntent(invoice);
+            const intent = await CreatePaymentIntent(invoice as unknown as IInvoice<"credit_card">);
 
             const customer = await CustomerModel.findOne({
                 $or: [

--- a/packages/interfaces/Invoice.interface.d.ts
+++ b/packages/interfaces/Invoice.interface.d.ts
@@ -6,7 +6,13 @@ import { IPayments } from "./Payments.interface";
 import { IProduct } from "./Products.interface";
 import { ITransactions } from "./Transactions.interface";
 
-export interface IInvoice<PM extends keyof IPayments = "none">
+export interface IInvoice<
+    PM extends keyof IPayments = "none",
+    /**
+     * S for Status
+     */
+    S extends extendedOrderStatus = "active",
+    >
 {
     id: any;
     uid: `INV_${string}`;
@@ -24,7 +30,9 @@ export interface IInvoice<PM extends keyof IPayments = "none">
     currency: TPaymentCurrency;
     notified: boolean;
     extra: {
-        stripe_payment_intent_id?: PM extends "credit_card" ? string : undefined;
+        stripe_payment_intent_id: PM extends "credit_card" ? string : undefined;
+        // If S is `refunded` then we mark it here it is refunded
+        refunded?: S extends "refunded" ? true : undefined;
         [key: string]: any;
     }
 }

--- a/packages/interfaces/Invoice.interface.d.ts
+++ b/packages/interfaces/Invoice.interface.d.ts
@@ -6,44 +6,7 @@ import { IPayments } from "./Payments.interface";
 import { IProduct } from "./Products.interface";
 import { ITransactions } from "./Transactions.interface";
 
-/**
- * @typedef InvoiceCreate
- * @property {Array.<Transactions>} transactions
- * @property {number} amount
- * @property {Array.<InvoiceItem>} items
- * @property {string} payment_method
- * @property {InvoiceDates.model} dates
- * @property {Status} status
- * @property {number} tax_rate
- * @property {string} notes
- * @property {boolean} paid
- */
-
-/**
- * @typedef InvoiceItem
- * @property {string} notes
- * @property {number} amount
- * @property {boolean} taxed
- */
-
-/**
- * @typedef InvoiceDates
- * @property {string} invoice_date
- * @property {string} due_date
- */
-
-/**
- * @typedef Status
- * @property {string} active
- * @property {string} pending
- * @property {string} draft
- * @property {string} fraud
- * @property {string} cancelled
- * @property {string} refunded
- * @property {string} collections
- * @property {string} payment_pending
- */
-export interface IInvoice
+export interface IInvoice<PM extends keyof IPayments = "none">
 {
     id: any;
     uid: `INV_${string}`;
@@ -60,6 +23,10 @@ export interface IInvoice
     paid: boolean;
     currency: TPaymentCurrency;
     notified: boolean;
+    extra: {
+        stripe_payment_intent_id?: PM extends "credit_card" ? string : undefined;
+        [key: string]: any;
+    }
 }
 
 export interface IInvoiceMethods


### PR DESCRIPTION
Now possible to refund invoices.
Customer doesn't have a option but admins have, thus if editing a invoice you can refund it if `status` is `refunded`.

### Required options to refund:
* Status is `refunded`
* Invoice is marked as `paid`

![chrome_68Q8Ad9pNj](https://user-images.githubusercontent.com/57797792/169656647-aeb5cbfc-2892-48dd-94b8-885ac54ac7b5.gif)

### For automatic refund `credit card`
* Everything above
* Payment method is `credit_card`
* Extra data doesn't have refund as `true`

![chrome_jBqGqn3OYk](https://user-images.githubusercontent.com/57797792/169656706-5c1ea61f-c07c-488b-9752-54786601ece6.gif)



